### PR TITLE
chore: dep support go1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/brianvoe/gofakeit/v6 v6.16.0
 	github.com/bytedance/gopkg v0.0.0-20220509134931-d1878f638986
 	github.com/chenzhuoyu/iasm v0.0.0-20220520152703-997ea6739ce9
+	github.com/choleraehyq/pid v0.0.15 // indirect
 	github.com/cloudwego/kitex v0.3.2
 	github.com/cloudwego/thriftgo v0.1.2
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/chenzhuoyu/iasm v0.0.0-20220520152703-997ea6739ce9 h1:rAW+byBPuNGHFeZ
 github.com/chenzhuoyu/iasm v0.0.0-20220520152703-997ea6739ce9/go.mod h1:wOQ0nsbeOLa2awv8bUYFW/EHXbjQMlZ10fAlXDB2sz8=
 github.com/choleraehyq/pid v0.0.13 h1:Tc/jYjHC50SDCxSX+DWHfMmFqtwGR8EiQ08qJ/EK8zs=
 github.com/choleraehyq/pid v0.0.13/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
+github.com/choleraehyq/pid v0.0.15 h1:PejhUZowqxxssjwyaw4OZURRFjnvftZfeEWK9UoWPXU=
+github.com/choleraehyq/pid v0.0.15/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/kitex v0.3.2 h1:izfwJ/5KI1tLipGN7NmUwsnpRgkOnECc55V/7nx+xk0=
 github.com/cloudwego/kitex v0.3.2/go.mod h1:/XD07VpUD9VQWmmoepASgZ6iw//vgWikVA9MpzLC5i0=


### PR DESCRIPTION
#### What type of PR is this?
chore: bump github.com/choleraehyq/pid v0.0.15 to support go119


#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: test failed on go119
zh:

ef216a8
```
# github.com/choleraehyq/pid
C:\Users\ii64\go\pkg\mod\github.com\choleraehyq\pid@v0.0.13\pid_go1.5_amd64.s:28: expected pseudo-register; found R13
C:\Users\ii64\go\pkg\mod\github.com\choleraehyq\pid@v0.0.13\pid_go1.5_amd64.s:29: expected pseudo-register; found R14
asm: assembly of C:\Users\ii64\go\pkg\mod\github.com\choleraehyq\pid@v0.0.13\pid_go1.5_amd64.s failed
FAIL    github.com/cloudwego/frugal/fuzz/builder [build failed]
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
