### PR TITLE
fix: support typeless tags like `frugal:"1,default"`

### DIFF
--- a/internal/binary/defs/resolver.go
+++ b/internal/binary/defs/resolver.go
@@ -151,10 +151,13 @@ func doResolveFields(vt reflect.Type) ([]Field, error) {
             continue
         }
 
-        /* must have at least 3 fields: ID, Requiredness, Type */
-        if ft = strings.Split(tv, ","); len(ft) < 3 {
+        /* must have at least 2 fields: ID and Requiredness; Type and other options are optional */
+        if ft = strings.Split(tv, ","); len(ft) < 2 {
             return nil, fmt.Errorf("invalid tag for field %s.%s", vt, sf.Name)
-        }
+        } else if len(ft) == 2 {
+	    /* append ft with an empty Type field */
+            ft = append(ft, "")
+	}
 
         /* parse the field index */
         if id, err = strconv.ParseUint(strings.TrimSpace(ft[0]), 10, 16); err != nil {

--- a/internal/binary/defs/resolver_test.go
+++ b/internal/binary/defs/resolver_test.go
@@ -25,8 +25,11 @@ import (
 )
 
 type NoCopyStringFields struct {
-    NormalString string `frugal:"1,default,string"`
-    NoCopyString string `frugal:"2,default,string,nocopy"`
+    NormalString         string `frugal:"1,default,string"`
+    NoCopyString         string `frugal:"2,default,string,nocopy"`
+    TypelessString       string `frugal:"3,default"`
+    TypelessString2      string `frugal:"4,default,"`
+    NoCopyTypelessString string `frugal:"5,default,,nocopy"`
 }
 
 func TestResolver_StringOptions(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

fix: A bug fix

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: support typeless tags like `` `frugal:"1,default"` ``
zh: 支持未指明类型的 frugal tag，比如 `` `frugal:"1,default"` ``

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
fixes #8 