### PR TITLE
docs: readme demo should use cloudwego imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ package main
 import (
     "log"
 
-    "code.byted.org/kite/kitex/server"
+    "github.com/cloudwego/kitex/server"
     c "example.com/kitex_test/kitex_gen/a/b/c/echo"
     "github.com/cloudwego/kitex/pkg/remote/codec/thrift"
 )

--- a/README_cn.md
+++ b/README_cn.md
@@ -116,7 +116,7 @@ package main
 import (
     "log"
 
-    "code.byted.org/kite/kitex/server"
+    "github.com/cloudwego/kitex/server"
     c "example.com/kitex_test/kitex_gen/a/b/c/echo"
     "github.com/cloudwego/kitex/pkg/remote/codec/thrift"
 )


### PR DESCRIPTION
#### What type of PR is this?
docs: Documentation only changes

#### What this PR does / why we need it (en: English/zh: Chinese):
en: fixed the demo of Readme which wrongly imports bytedance internal pkg
zh:

#### Which issue(s) this PR fixes:
To import open source package from cloudwego