### PR TITLE
fix: remove rt.NoEscape which may lead to bad pointer fatal

### DIFF
--- a/fuzz/go.sum
+++ b/fuzz/go.sum
@@ -416,8 +416,8 @@ github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chenzhuoyu/iasm v0.9.0 h1:9fhXjVzq5hUy2gkhhgHl95zG2cEAhw9OSGs8toWWAwo=
-github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
+github.com/chenzhuoyu/iasm v0.9.1 h1:tUHQJXo3NhBqw6s33wkGn9SP3bvrWLdlVIJ3hQBL7P0=
+github.com/chenzhuoyu/iasm v0.9.1/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/choleraehyq/pid v0.0.15/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
 github.com/choleraehyq/pid v0.0.17 h1:BLBfHTllp2nRRbZ/cOFHKlx9oWJuMwKmp7GqB5d58Hk=
 github.com/choleraehyq/pid v0.0.17/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=

--- a/internal/binary/encoder/state.go
+++ b/internal/binary/encoder/state.go
@@ -53,6 +53,7 @@ type StateItem struct {
 }
 
 type RuntimeState struct {
-    St [defs.StackSize]StateItem    // Must be the first field.
-    Bm [1024]uint64                 // Bitmap, used for uniqueness check of set<i8> and set<i16>.
+    St  [defs.StackSize]StateItem    // Must be the first field.
+    Bm  [1024]uint64                 // Bitmap, used for uniqueness check of set<i8> and set<i16>.
+    Val unsafe.Pointer               // Pointer to the object to be encoded
 }

--- a/tests/deep_nested_test.go
+++ b/tests/deep_nested_test.go
@@ -1,0 +1,97 @@
+package tests
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/cloudwego/frugal"
+)
+
+type L0 struct {
+	L1 *L1 `thrift:"l1,1,optional" frugal:"1,optional,L1"`
+}
+type L1 struct {
+	L2 *L2 `thrift:"l2,1,optional" frugal:"1,optional,L2"`
+}
+type L2 struct {
+	L3 *L3 `thrift:"l3,1,optional" frugal:"1,optional,L3"`
+}
+type L3 struct {
+	L4 *L4 `thrift:"l4,1,optional" frugal:"1,optional,L4"`
+}
+type L4 struct {
+	L5 *L5 `thrift:"l5,1,optional" frugal:"1,optional,L5"`
+}
+type L5 struct {
+	L6 *L6 `thrift:"l6,1,optional" frugal:"1,optional,L6"`
+}
+type L6 struct {
+	L7 *L7 `thrift:"l7,1,optional" frugal:"1,optional,L7"`
+}
+type L7 struct {
+	L8 *L8 `thrift:"l8,1,optional" frugal:"1,optional,L8"`
+}
+type L8 struct {
+	L9 *L9 `thrift:"l9,1,optional" frugal:"1,optional,L9"`
+}
+type L9 struct {
+	L10 *L10 `thrift:"l10,1,optional" frugal:"1,optional,L10"`
+}
+type L10 struct {
+	L11 *L11 `thrift:"l11,1,optional" frugal:"1,optional,L11"`
+}
+type L11 struct {
+	L12 *L12 `thrift:"l12,1,optional" frugal:"1,optional,L12"`
+}
+type L12 struct {
+	L13 *L13 `thrift:"l13,1,optional" frugal:"1,optional,L13"`
+}
+type L13 struct {
+	L14 *L14 `thrift:"l14,1,optional" frugal:"1,optional,L14"`
+}
+type L14 struct {
+	L15 *L15 `thrift:"l15,1,optional" frugal:"1,optional,L15"`
+}
+type L15 struct {
+	L16 *L16 `thrift:"l16,1,optional" frugal:"1,optional,L16"`
+}
+type L16 struct {
+	L17 *L17 `thrift:"l17,1,optional" frugal:"1,optional,L17"`
+}
+type L17 struct {
+	L18 *L18 `thrift:"l18,1,optional" frugal:"1,optional,L18"`
+}
+type L18 struct {
+	L19 *L19 `thrift:"l19,1,optional" frugal:"1,optional,L19"`
+}
+type L19 struct {
+	L20 *L20 `thrift:"l20,1,optional" frugal:"1,optional,L20"`
+}
+type L20 struct {
+	End *bool `thrift:"bool,1,optional" frugal:"1,optional,bool"`
+}
+
+var (
+	deepNested = &L0{&L1{&L2{&L3{&L4{&L5{
+		&L6{&L7{&L8{&L9{&L10{
+			&L11{&L12{&L13{&L14{&L15{
+				&L16{&L17{&L18{&L19{&L20{}}}}}}}}}}}}}}}}}}}}}
+)
+
+func TestDeepNested(t *testing.T) {
+	exit := make(chan int)
+	go func() {
+		for {
+			select {
+			case <-exit:
+				t.Logf("exit gc loop")
+			default:
+				runtime.GC()
+			}
+		}
+	}()
+	for i := 0; i < 100; i++ {
+		frugal.EncodedSize(deepNested)
+	}
+	exit <- 0
+}

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -21,8 +21,8 @@ github.com/bytedance/gopkg v0.0.0-20220413063733-65bf48ffb3a7/go.mod h1:2ZlV9BaU
 github.com/bytedance/gopkg v0.0.0-20220531084716-665b4f21126f h1:2YCF3cgO6XCub0HIsLrA8ZGhmAPGZfOeSaGjT6Kx4Mc=
 github.com/bytedance/gopkg v0.0.0-20220531084716-665b4f21126f/go.mod h1:2ZlV9BaUH4+NXIBF0aMdKKAnHTzqH+iMU4KUjAbL23Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chenzhuoyu/iasm v0.9.0 h1:9fhXjVzq5hUy2gkhhgHl95zG2cEAhw9OSGs8toWWAwo=
-github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
+github.com/chenzhuoyu/iasm v0.9.1 h1:tUHQJXo3NhBqw6s33wkGn9SP3bvrWLdlVIJ3hQBL7P0=
+github.com/chenzhuoyu/iasm v0.9.1/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/choleraehyq/pid v0.0.16/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
 github.com/choleraehyq/pid v0.0.17 h1:BLBfHTllp2nRRbZ/cOFHKlx9oWJuMwKmp7GqB5d58Hk=
 github.com/choleraehyq/pid v0.0.17/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: `rt.NoEscape` is used to avoid an extra allocation which might be expensive for small objects, but it may lead to invalid pointer after the goroutine's stack is reallocated (because `efv` is moved to another address, invalidating the saved `&efv.Value`). This fix solves this problem by introducing introducing a new member `Val` in `encoder.RuntimeState` as the replacement of `efv.Value`.
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
