### PR TITLE
feat: add an option to enable emu

### DIFF
--- a/options.go
+++ b/options.go
@@ -17,14 +17,14 @@
 package frugal
 
 import (
-	"fmt"
+    `fmt`
 
-	"github.com/cloudwego/frugal/internal/opts"
-	"github.com/cloudwego/frugal/internal/utils"
+    `github.com/cloudwego/frugal/internal/opts`
+    `github.com/cloudwego/frugal/internal/utils`
 )
 
 const (
-	_MinILSize = 1024
+    _MinILSize = 1024
 )
 
 // Option is the property setter function for opts.Options.
@@ -40,11 +40,11 @@ type Option func(*opts.Options)
 //
 // The default value of this option is "5".
 func WithMaxInlineDepth(depth int) Option {
-	if depth < 0 {
-		panic(fmt.Sprintf("frugal: invalid inline depth: %d", depth))
-	} else {
-		return func(o *opts.Options) { o.MaxInlineDepth = depth }
-	}
+    if depth < 0 {
+        panic(fmt.Sprintf("frugal: invalid inline depth: %d", depth))
+    } else {
+        return func(o *opts.Options) { o.MaxInlineDepth = depth }
+    }
 }
 
 // WithMaxInlineILSize sets the maximum IL instruction count before not inlining.
@@ -58,11 +58,11 @@ func WithMaxInlineDepth(depth int) Option {
 //
 // The default value of this option is "50000".
 func WithMaxInlineILSize(size int) Option {
-	if size != 0 && size < _MinILSize {
-		panic(fmt.Sprintf("frugal: invalid inline IL size: %d", size))
-	} else {
-		return func(o *opts.Options) { o.MaxInlineILSize = size }
-	}
+    if size != 0 && size < _MinILSize {
+        panic(fmt.Sprintf("frugal: invalid inline IL size: %d", size))
+    } else {
+        return func(o *opts.Options) { o.MaxInlineILSize = size }
+    }
 }
 
 // WithMaxPretouchDepth controls how deep the compiler goes to compile
@@ -79,11 +79,11 @@ func WithMaxInlineILSize(size int) Option {
 // This option is only available when performing pretouch, otherwise it is
 // ignored and do not have any effect.
 func WithMaxPretouchDepth(depth int) Option {
-	if depth < 0 {
-		panic(fmt.Sprintf("frugal: invalid pretouch depth: %d", depth))
-	} else {
-		return func(o *opts.Options) { o.MaxPretouchDepth = depth }
-	}
+    if depth < 0 {
+        panic(fmt.Sprintf("frugal: invalid pretouch depth: %d", depth))
+    } else {
+        return func(o *opts.Options) { o.MaxPretouchDepth = depth }
+    }
 }
 
 // SetMaxInlineDepth sets the default maximum inlining depth for all types from
@@ -96,8 +96,8 @@ func WithMaxPretouchDepth(depth int) Option {
 //
 // Returns the old opts.MaxInlineDepth value.
 func SetMaxInlineDepth(depth int) int {
-	depth, opts.MaxInlineDepth = opts.MaxInlineDepth, depth
-	return depth
+    depth, opts.MaxInlineDepth = opts.MaxInlineDepth, depth
+    return depth
 }
 
 // SetMaxInlineILSize sets the default maximum inlining IL instructions for all
@@ -110,11 +110,11 @@ func SetMaxInlineDepth(depth int) int {
 //
 // Returns the old opts.MaxInlineILSize value.
 func SetMaxInlineILSize(size int) int {
-	size, opts.MaxInlineILSize = opts.MaxInlineILSize, size
-	return size
+    size, opts.MaxInlineILSize = opts.MaxInlineILSize, size
+    return size
 }
 
 // SetForceEmulator enables emulator.
 func SetForceEmulator(enable bool) {
-	utils.ForceEmulator = enable
+    utils.ForceEmulator = enable
 }

--- a/options.go
+++ b/options.go
@@ -114,6 +114,7 @@ func SetMaxInlineILSize(size int) int {
 	return size
 }
 
+// SetForceEmulator enables emulator.
 func SetForceEmulator(enable bool) {
 	utils.ForceEmulator = enable
 }

--- a/options.go
+++ b/options.go
@@ -17,13 +17,14 @@
 package frugal
 
 import (
-    `fmt`
+	"fmt"
 
-    `github.com/cloudwego/frugal/internal/opts`
+	"github.com/cloudwego/frugal/internal/opts"
+	"github.com/cloudwego/frugal/internal/utils"
 )
 
 const (
-    _MinILSize = 1024
+	_MinILSize = 1024
 )
 
 // Option is the property setter function for opts.Options.
@@ -39,11 +40,11 @@ type Option func(*opts.Options)
 //
 // The default value of this option is "5".
 func WithMaxInlineDepth(depth int) Option {
-    if depth < 0 {
-        panic(fmt.Sprintf("frugal: invalid inline depth: %d", depth))
-    } else {
-        return func(o *opts.Options) { o.MaxInlineDepth = depth }
-    }
+	if depth < 0 {
+		panic(fmt.Sprintf("frugal: invalid inline depth: %d", depth))
+	} else {
+		return func(o *opts.Options) { o.MaxInlineDepth = depth }
+	}
 }
 
 // WithMaxInlineILSize sets the maximum IL instruction count before not inlining.
@@ -57,11 +58,11 @@ func WithMaxInlineDepth(depth int) Option {
 //
 // The default value of this option is "50000".
 func WithMaxInlineILSize(size int) Option {
-    if size != 0 && size < _MinILSize {
-        panic(fmt.Sprintf("frugal: invalid inline IL size: %d", size))
-    } else {
-        return func(o *opts.Options) { o.MaxInlineILSize = size }
-    }
+	if size != 0 && size < _MinILSize {
+		panic(fmt.Sprintf("frugal: invalid inline IL size: %d", size))
+	} else {
+		return func(o *opts.Options) { o.MaxInlineILSize = size }
+	}
 }
 
 // WithMaxPretouchDepth controls how deep the compiler goes to compile
@@ -78,11 +79,11 @@ func WithMaxInlineILSize(size int) Option {
 // This option is only available when performing pretouch, otherwise it is
 // ignored and do not have any effect.
 func WithMaxPretouchDepth(depth int) Option {
-    if depth < 0 {
-        panic(fmt.Sprintf("frugal: invalid pretouch depth: %d", depth))
-    } else {
-        return func(o *opts.Options) { o.MaxPretouchDepth = depth }
-    }
+	if depth < 0 {
+		panic(fmt.Sprintf("frugal: invalid pretouch depth: %d", depth))
+	} else {
+		return func(o *opts.Options) { o.MaxPretouchDepth = depth }
+	}
 }
 
 // SetMaxInlineDepth sets the default maximum inlining depth for all types from
@@ -95,8 +96,8 @@ func WithMaxPretouchDepth(depth int) Option {
 //
 // Returns the old opts.MaxInlineDepth value.
 func SetMaxInlineDepth(depth int) int {
-    depth, opts.MaxInlineDepth = opts.MaxInlineDepth, depth
-    return depth
+	depth, opts.MaxInlineDepth = opts.MaxInlineDepth, depth
+	return depth
 }
 
 // SetMaxInlineILSize sets the default maximum inlining IL instructions for all
@@ -109,6 +110,10 @@ func SetMaxInlineDepth(depth int) int {
 //
 // Returns the old opts.MaxInlineILSize value.
 func SetMaxInlineILSize(size int) int {
-    size, opts.MaxInlineILSize = opts.MaxInlineILSize, size
-    return size
+	size, opts.MaxInlineILSize = opts.MaxInlineILSize, size
+	return size
+}
+
+func SetForceEmulator(enable bool) {
+	utils.ForceEmulator = enable
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
