### PR TITLE
Fix options like WithXXX not working and change default MaxInlineDepth=2

### DIFF
--- a/internal/binary/encoder/compiler.go
+++ b/internal/binary/encoder/compiler.go
@@ -172,6 +172,13 @@ func (self *Compiler) Apply(o opts.Options) *Compiler {
     return self
 }
 
+func (self *Compiler) resetState() *Compiler {
+    o := self.o // prevent from resetting opts
+    resetCompiler(self)
+    self.o = o
+    return self
+}
+
 func (self *Compiler) Compile(vt reflect.Type) (_ Program, err error) {
     ret := newProgram()
     vtp := (*defs.Type)(nil)
@@ -188,13 +195,13 @@ func (self *Compiler) Compile(vt reflect.Type) (_ Program, err error) {
     /* object measuring */
     i := ret.pc()
     ret.add(OP_if_hasbuf)
-    resetCompiler(self).measure(&ret, 0, vtp, ret.pc())
+    self.resetState().measure(&ret, 0, vtp, ret.pc())
 
     /* object encoding */
     j := ret.pc()
     ret.add(OP_goto)
     ret.pin(i)
-    resetCompiler(self).compile(&ret, 0, vtp, ret.pc())
+    self.resetState().compile(&ret, 0, vtp, ret.pc())
 
     /* halt the program */
     ret.pin(j)

--- a/internal/binary/encoder/compiler.go
+++ b/internal/binary/encoder/compiler.go
@@ -173,7 +173,7 @@ func (self *Compiler) Apply(o opts.Options) *Compiler {
 }
 
 func (self *Compiler) resetState() *Compiler {
-    o := self.o // prevent from resetting opts
+    o := self.o // prevent resetting opts
     resetCompiler(self)
     self.o = o
     return self

--- a/internal/opts/limits.go
+++ b/internal/opts/limits.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-    _DefaultMaxInlineDepth  = 5     // cutoff at 5 levels of inlining
+    _DefaultMaxInlineDepth  = 2     // cutoff at 2 levels of inlining
     _DefaultMaxInlineILSize = 50000 // cutoff at 50k of IL instructions
 )
 

--- a/options.go
+++ b/options.go
@@ -37,7 +37,7 @@ type Option func(*opts.Options)
 //
 // Set this option to "0" disables this limit, which means inlining everything.
 //
-// The default value of this option is "5".
+// The default value of this option is "2".
 func WithMaxInlineDepth(depth int) Option {
     if depth < 0 {
         panic(fmt.Sprintf("frugal: invalid inline depth: %d", depth))
@@ -91,7 +91,7 @@ func WithMaxPretouchDepth(depth int) Option {
 // This value can also be configured with the `FRUGAL_MAX_INLINE_DEPTH`
 // environment variable.
 //
-// The default value of this option is "5".
+// The default value of this option is "2".
 //
 // Returns the old opts.MaxInlineDepth value.
 func SetMaxInlineDepth(depth int) int {


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复 options 函数 WithXXX 不起作用，并且修改了 MaxInlineDepth为2

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
We found that it's taking too long when JIT, and it caused unstable issue when handling the 1st request for each instance.
We tried to `Pretouch` structs to be used, but it's still taking too long to be ready coz we have so many structs to touch.
So decided to change the `MaxInlineDepth` value to smaller.
after the change, minor performance impacts are expected. You can `Pretouch` with `WithMaxInlineDepth` for large structs if needed.

zh(optional): 
我们发现JIT消耗的时间过长，这样导致每个实例在处理第一个请求不稳定，导致大量超时。
我们尝试通过  `Pretouch` 来优化这种情况，但是我们有太多结构体需要touch了。
因此我们决定把  `MaxInlineDepth`  改小。
在修改过后，会有一定的性能的影响，这是预期内的，如有需有你可以使用  `WithMaxInlineDepth` 来对大的结构体进行Pretouch


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
