### PR TITLE
refactor: bump to go1.20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   unittest-amd64:
     strategy:
       matrix:
-        go: [ "1.18", oldstable, stable ]
+        go: [ "1.20", oldstable, stable ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudwego/frugal
 
-go 1.18
+go 1.20
 
 require (
 	github.com/cloudwego/gopkg v0.1.2

--- a/internal/reflect/decoder.go
+++ b/internal/reflect/decoder.go
@@ -182,14 +182,9 @@ func decodeStringNoCopy(t *tType, b []byte, p unsafe.Pointer) (i int, err error)
 	}
 
 	if t.Tag == defs.T_binary {
-		h := (*sliceHeader)(p)
-		h.Data = unsafe.Pointer(&b[i])
-		h.Len = l
-		h.Cap = l
-	} else { //  convert to str
-		h := (*stringHeader)(p)
-		h.Data = unsafe.Pointer(&b[i])
-		h.Len = l
+		*(*[]byte)(p) = unsafe.Slice(&b[i], l)
+	} else {
+		*(*string)(p) = unsafe.String(&b[i], l)
 	}
 	i += l
 	return
@@ -224,16 +219,11 @@ func (d *tDecoder) decodeType(t *tType, b []byte, p unsafe.Pointer, maxdepth int
 
 		x := d.Malloc(l, 1, 0)
 		if t.Tag == defs.T_binary {
-			h := (*sliceHeader)(p)
-			h.Data = x
-			h.Len = l
-			h.Cap = l
-		} else { //  convert to str
-			h := (*stringHeader)(p)
-			h.Data = x
-			h.Len = l
+			*(*[]byte)(p) = unsafe.Slice((*byte)(x), l)
+		} else {
+			*(*string)(p) = unsafe.String((*byte)(x), l)
 		}
-		copyn(x, b[i:], l)
+		copy(unsafe.Slice((*byte)(x), l), b[i:])
 		i += l
 		return i, nil
 

--- a/internal/reflect/descmap.go
+++ b/internal/reflect/descmap.go
@@ -16,15 +16,13 @@
 
 package reflect
 
-import (
-	"sync/atomic"
-	"unsafe"
-)
+import "sync/atomic"
 
 // mapStructDesc represents a read-lock-free hashmap for *structDesc like sync.Map.
 // it's NOT designed for writes.
+// Each slot is an atomic.Pointer so that Set only reallocs the target slot.
 type mapStructDesc struct {
-	p unsafe.Pointer // for atomic, point to hashtable
+	slots [mapStructDescBuckets + 1]atomic.Pointer[[]mapStructDescItem]
 }
 
 // XXX: fixed size to make it simple,
@@ -37,19 +35,18 @@ type mapStructDescItem struct {
 }
 
 func newMapStructDesc() *mapStructDesc {
-	m := &mapStructDesc{}
-	buckets := make([][]mapStructDescItem, mapStructDescBuckets+1) // [0] - [0xffff]
-	atomic.StorePointer(&m.p, unsafe.Pointer(&buckets))
-	return m
+	return &mapStructDesc{}
 }
 
 // Get ...
 func (m *mapStructDesc) Get(abiType uintptr) *structDesc {
-	buckets := *(*[][]mapStructDescItem)(atomic.LoadPointer(&m.p))
-	dd := buckets[abiType&mapStructDescBuckets]
-	for i := range dd {
-		if dd[i].abiType == abiType {
-			return dd[i].sd
+	slot := m.slots[abiType&mapStructDescBuckets].Load()
+	if slot == nil {
+		return nil
+	}
+	for i := range *slot {
+		if (*slot)[i].abiType == abiType {
+			return (*slot)[i].sd
 		}
 	}
 	return nil
@@ -61,10 +58,21 @@ func (m *mapStructDesc) Set(abiType uintptr, sd *structDesc) {
 	if m.Get(abiType) == sd {
 		return
 	}
-	oldBuckets := *(*[][]mapStructDescItem)(atomic.LoadPointer(&m.p))
-	newBuckets := make([][]mapStructDescItem, mapStructDescBuckets+1)
-	copy(newBuckets, oldBuckets)
 	bk := abiType & mapStructDescBuckets
-	newBuckets[bk] = append(newBuckets[bk], mapStructDescItem{abiType: abiType, sd: sd})
-	atomic.StorePointer(&m.p, unsafe.Pointer(&newBuckets))
+	var old []mapStructDescItem
+	if p := m.slots[bk].Load(); p != nil {
+		old = *p
+	}
+	// alloc cap=len+1 upfront so append below won't realloc.
+	items := make([]mapStructDescItem, len(old), len(old)+1)
+	copy(items, old)
+	for i := range items {
+		if items[i].abiType == abiType {
+			items[i].sd = sd
+			m.slots[bk].Store(&items)
+			return
+		}
+	}
+	items = append(items, mapStructDescItem{abiType: abiType, sd: sd})
+	m.slots[bk].Store(&items)
 }

--- a/internal/reflect/descmap_test.go
+++ b/internal/reflect/descmap_test.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reflect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapStructDesc_GetEmpty(t *testing.T) {
+	m := newMapStructDesc()
+	assert.Nil(t, m.Get(1))
+	assert.Nil(t, m.Get(0))
+	assert.Nil(t, m.Get(0xffff))
+}
+
+func TestMapStructDesc_SetGet(t *testing.T) {
+	m := newMapStructDesc()
+	sd1 := &structDesc{}
+	sd2 := &structDesc{}
+
+	m.Set(1, sd1)
+	assert.Equal(t, sd1, m.Get(1))
+	assert.Nil(t, m.Get(2))
+
+	m.Set(2, sd2)
+	assert.Equal(t, sd1, m.Get(1))
+	assert.Equal(t, sd2, m.Get(2))
+}
+
+func TestMapStructDesc_Update(t *testing.T) {
+	m := newMapStructDesc()
+	sd1 := &structDesc{}
+	sd2 := &structDesc{}
+
+	m.Set(1, sd1)
+	assert.Equal(t, sd1, m.Get(1))
+
+	// update same key with new value
+	m.Set(1, sd2)
+	assert.Equal(t, sd2, m.Get(1))
+
+	// slot should have exactly 1 item, not 2
+	bk := uintptr(1) & mapStructDescBuckets
+	slot := m.slots[bk].Load()
+	assert.Equal(t, 1, len(*slot))
+}
+
+func TestMapStructDesc_SetNoop(t *testing.T) {
+	m := newMapStructDesc()
+	sd := &structDesc{}
+
+	m.Set(1, sd)
+	// set same key+value again should be a noop
+	m.Set(1, sd)
+
+	bk := uintptr(1) & mapStructDescBuckets
+	slot := m.slots[bk].Load()
+	assert.Equal(t, 1, len(*slot))
+}
+
+func TestMapStructDesc_HashCollision(t *testing.T) {
+	m := newMapStructDesc()
+	sd1 := &structDesc{}
+	sd2 := &structDesc{}
+
+	// keys that map to the same bucket
+	k1 := uintptr(1)
+	k2 := k1 + mapStructDescBuckets + 1 // same bucket as k1
+
+	m.Set(k1, sd1)
+	m.Set(k2, sd2)
+
+	assert.Equal(t, sd1, m.Get(k1))
+	assert.Equal(t, sd2, m.Get(k2))
+
+	// both in the same slot
+	bk := k1 & mapStructDescBuckets
+	slot := m.slots[bk].Load()
+	assert.Equal(t, 2, len(*slot))
+}
+
+func TestMapStructDesc_UpdateWithCollision(t *testing.T) {
+	m := newMapStructDesc()
+	sd1 := &structDesc{}
+	sd2 := &structDesc{}
+	sd3 := &structDesc{}
+
+	k1 := uintptr(1)
+	k2 := k1 + mapStructDescBuckets + 1
+
+	m.Set(k1, sd1)
+	m.Set(k2, sd2)
+
+	// update k1, should not affect k2
+	m.Set(k1, sd3)
+	assert.Equal(t, sd3, m.Get(k1))
+	assert.Equal(t, sd2, m.Get(k2))
+
+	bk := k1 & mapStructDescBuckets
+	slot := m.slots[bk].Load()
+	assert.Equal(t, 2, len(*slot))
+}

--- a/internal/reflect/hack.go
+++ b/internal/reflect/hack.go
@@ -150,14 +150,8 @@ type mapIter struct {
 }
 
 // newMapIter creates reflect.MapIter for reflect.Value.
-// for go1.17, go1.18, rv.MapRange() will cause one more allocation
-// for >=go1.19, can use rv.MapRange() directly.
-// see: https://github.com/golang/go/commit/c5edd5f616b4ee4bbaefdb1579c6078e7ed7e84e
-// TODO: remove this func, and use mapIter{rv.MapRange()} when >=go1.19
 func newMapIter(rv reflect.Value) mapIter {
-	ret := mapIter{}
-	(*hackMapIter)(unsafe.Pointer(&ret.MapIter)).m = rv
-	return ret
+	return mapIter{*rv.MapRange()}
 }
 
 func (m *mapIter) Next() (unsafe.Pointer, unsafe.Pointer) {
@@ -220,26 +214,16 @@ func rtTypePtr(rt reflect.Type) uintptr {
 	return (*iface)(unsafe.Pointer(&rt)).data
 }
 
-// same as reflect.StringHeader
-type stringHeader struct {
-	Data unsafe.Pointer
-	Len  int
-}
-
-// same as reflect.SliceHeader
 type sliceHeader struct {
 	Data unsafe.Pointer
 	Len  int
 	Cap  int
 }
 
-var (
-	emptyslice = make([]byte, 0)
-
-	// for slice, Data should points to zerobase var in `runtime`
-	// so that it can represent as []type{} instead of []type(nil)
-	zerobase = ((*sliceHeader)(unsafe.Pointer(&emptyslice))).Data
-)
+// zerobase is the Data pointer of an empty slice.
+// For slice, Data should point to the zerobase var in `runtime`
+// so that it can represent as []type{} instead of []type(nil).
+var zerobase = unsafe.Pointer(unsafe.SliceData(make([]byte, 0)))
 
 func (h *sliceHeader) Zero() {
 	h.Len = 0

--- a/internal/reflect/unknownfields.go
+++ b/internal/reflect/unknownfields.go
@@ -48,11 +48,7 @@ func (p *unknownFields) Size() int {
 func (p *unknownFields) Copy(b []byte) []byte {
 	sz := p.Size()
 	data := mallocgc(uintptr(sz), 0, false) //  without zeroing
-	ret := []byte{}
-	h := (*sliceHeader)(unsafe.Pointer(&ret))
-	h.Data = data
-	h.Len = sz
-	h.Cap = sz
+	ret := unsafe.Slice((*byte)(data), sz)
 	off := 0
 	for _, x := range p.offs {
 		copy(ret[off:], b[x.off:x.off+x.sz])

--- a/internal/reflect/utils.go
+++ b/internal/reflect/utils.go
@@ -23,17 +23,6 @@ import (
 	"unsafe"
 )
 
-// copyn copies n bytes from src to dst addr.
-// it mainly used by decoder of tSTRING
-func copyn(dst unsafe.Pointer, src []byte, n int) {
-	var b []byte
-	hdr := (*sliceHeader)(unsafe.Pointer(&b))
-	hdr.Data = dst
-	hdr.Cap = n
-	hdr.Len = n
-	copy(b, src)
-}
-
 // only be used when NewRequiredFieldNotSetException
 func lookupFieldName(rt reflect.Type, offset uintptr) string {
 	for rt.Kind() == reflect.Ptr {
@@ -56,33 +45,19 @@ func checkUniqueness(t *tType, h *sliceHeader) error {
 	var uniq bool
 	switch t.T {
 	case tBOOL:
-		var vv []bool
-		*(*sliceHeader)(unsafe.Pointer(&vv)) = *h
-		uniq = checkUniquenessBool(vv)
+		uniq = checkUnique(unsafe.Slice((*bool)(h.Data), h.Len))
 	case tI08:
-		var vv []int8
-		*(*sliceHeader)(unsafe.Pointer(&vv)) = *h
-		uniq = checkUniquenessInt8(vv)
+		uniq = checkUnique(unsafe.Slice((*int8)(h.Data), h.Len))
 	case tI16:
-		var vv []int16
-		*(*sliceHeader)(unsafe.Pointer(&vv)) = *h
-		uniq = checkUniquenessInt16(vv)
+		uniq = checkUnique(unsafe.Slice((*int16)(h.Data), h.Len))
 	case tI32:
-		var vv []int32
-		*(*sliceHeader)(unsafe.Pointer(&vv)) = *h
-		uniq = checkUniquenessInt32(vv)
+		uniq = checkUnique(unsafe.Slice((*int32)(h.Data), h.Len))
 	case tI64, tENUM:
-		var vv []int64
-		*(*sliceHeader)(unsafe.Pointer(&vv)) = *h
-		uniq = checkUniquenessInt64(vv)
+		uniq = checkUnique(unsafe.Slice((*int64)(h.Data), h.Len))
 	case tDOUBLE:
-		var vv []float64
-		*(*sliceHeader)(unsafe.Pointer(&vv)) = *h
-		uniq = checkUniquenessFloat64(vv)
+		uniq = checkUnique(unsafe.Slice((*float64)(h.Data), h.Len))
 	case tSTRING:
-		var ss []string
-		*(*sliceHeader)(unsafe.Pointer(&ss)) = *h
-		uniq = checkUniquenessString(ss)
+		uniq = checkUnique(unsafe.Slice((*string)(h.Data), h.Len))
 	default: // tSTRUCT?
 		// NOTE: tSTRUCT is not always comparable, and it's not common for set
 		return nil
@@ -93,83 +68,9 @@ func checkUniqueness(t *tType, h *sliceHeader) error {
 	return nil
 }
 
-// XXX: checkUniqueness funcs use generics when we start to use newer go versions.
-func checkUniquenessBool(vv []bool) bool {
-	l := len(vv)
-	for i := 0; i < l; i++ {
-		for j := i + 1; j < l; j++ {
-			if vv[i] == vv[j] {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func checkUniquenessInt8(vv []int8) bool {
-	l := len(vv)
-	for i := 0; i < l; i++ {
-		for j := i + 1; j < l; j++ {
-			if vv[i] == vv[j] {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func checkUniquenessInt16(vv []int16) bool {
-	l := len(vv)
-	for i := 0; i < l; i++ {
-		for j := i + 1; j < l; j++ {
-			if vv[i] == vv[j] {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func checkUniquenessInt32(vv []int32) bool {
-	l := len(vv)
-	for i := 0; i < l; i++ {
-		for j := i + 1; j < l; j++ {
-			if vv[i] == vv[j] {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func checkUniquenessInt64(vv []int64) bool {
-	l := len(vv)
-	for i := 0; i < l; i++ {
-		for j := i + 1; j < l; j++ {
-			if vv[i] == vv[j] {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func checkUniquenessFloat64(vv []float64) bool {
-	l := len(vv)
-	for i := 0; i < l; i++ {
-		for j := i + 1; j < l; j++ {
-			if vv[i] == vv[j] {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func checkUniquenessString(vv []string) bool {
-	l := len(vv)
-	for i := 0; i < l; i++ {
-		for j := i + 1; j < l; j++ {
+func checkUnique[T comparable](vv []T) bool {
+	for i := range vv {
+		for j := i + 1; j < len(vv); j++ {
 			if vv[i] == vv[j] {
 				return false
 			}


### PR DESCRIPTION
- Update go.mod to go 1.20
- descmap: use per-slot atomic.Pointer[T] instead of single atomic pointer to entire buckets array, only realloc the affected slot on Set
- hack: simplify newMapIter using rv.MapRange() (go1.19), remove stringHeader, use unsafe.SliceData for zerobase (go1.20)
- decoder: replace stringHeader/sliceHeader with unsafe.String and unsafe.Slice for string/binary decoding (go1.20)
- utils: inline copyn with unsafe.Slice, replace 7 checkUniqueness functions with single generic checkUnique[T comparable]
- unknownfields: use unsafe.Slice instead of sliceHeader manipulation
- Add descmap unit tests